### PR TITLE
Update Fedora version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Marvell_MSU_Linux_v4.1.0.2032.zip
 mrvl_utl_msu_4.1.10.2042_linux_x86-64.tgz
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache wget && \
 RUN tar xzf mrvl_utl_msu_4.1.10.2046_linux_x86-64.tgz
 
 	
-FROM fedora:31 AS final
+FROM fedora:35 AS final
 
 # libxcrypt-compat, libnsl: apache webserver for MSU
 # procps: install script
@@ -36,7 +36,6 @@ RUN rm /opt/marvell/storage/db/mvraidsvc.log && \
 # redirect apache logs
 RUN sed -ie 's:CustomLog "logs/access_log":CustomLog "/proc/self/fd/1":' /opt/marvell/storage/apache2/conf/httpd.conf && \
 	sed -ie 's:ErrorLog "logs/error_log":ErrorLog "/proc/self/fd/2":' /opt/marvell/storage/apache2/conf/httpd.conf
-	
 
 COPY scripts/startup.sh /startup.sh
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ docker-compose build
 docker-compose up -d
 ```
 
-After the container is started you can access the web UI on port 8845. The default user and password is *root*.
+After the container is started you can access the web UI on port [8845](http://localhost:8845/). The default user and password is *root*.
 
-Alternatively the CLI can be startet with
+Alternatively the CLI can be started with
 
 ```sh
 docker-compose run --rm msu cli


### PR DESCRIPTION
Thanks for this!

Thought id suggest some small adjustments.

* Fedora version 31 reached End-of-life on the 2020-11-24.
* Improve spelling in readme
* Add link to localhost web UI
* Add IDEA temp folder to gitignore (for the ones of us who likes IDEs ^^)